### PR TITLE
Replace "base" with "parent"

### DIFF
--- a/lib/Mail/Milter/Authentication/Handler/Blocker.pm
+++ b/lib/Mail/Milter/Authentication/Handler/Blocker.pm
@@ -1,7 +1,7 @@
 package Mail::Milter::Authentication::Handler::Blocker;
 use strict;
 use warnings;
-use base 'Mail::Milter::Authentication::Handler';
+use parent 'Mail::Milter::Authentication::Handler';
 # VERSION
 # ABSTRACT: Block mail based on simple rules
 


### PR DESCRIPTION
As per the documentation, parent is encouraged these days: "Unless you are using the fields pragma, consider this module discouraged in favor of the lighter-weight parent."

Both are core in 5.10+